### PR TITLE
GreyCat + RocksDB on Raspberry Pi 3

### DIFF
--- a/plugins/rocksdb/src/main/java/greycat/rocksdb/LibraryLoader.java
+++ b/plugins/rocksdb/src/main/java/greycat/rocksdb/LibraryLoader.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The GreyCat Authors.  All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package greycat.rocksdb;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+public class LibraryLoader {
+
+    private static final String ARM_EXTENSION = ".so";
+
+    public static void loadArmLibrary(String fileName) {
+        final String tmpDir = System.getenv("ROCKSDB_SHAREDLIB_DIR");
+        if(tmpDir == null || tmpDir.isEmpty()) {
+            throw new RuntimeException("Please set ROCKSDB_SHAREDLIB_DIR environment variable with a folder");
+        }
+        try {
+            File tmpFile = new File(tmpDir,fileName + ARM_EXTENSION);
+            tmpFile.createNewFile();
+            tmpFile.deleteOnExit();
+
+            try (final InputStream is = LibraryLoader.class.getClassLoader().getResourceAsStream("arm/" + fileName + ARM_EXTENSION)) {
+                if (is == null) {
+                    throw new RuntimeException(fileName + " was not found inside JAR.");
+                } else {
+                    Files.copy(is, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+            System.load(tmpFile.getAbsolutePath());
+        }catch (IOException e) {
+            throw new RuntimeException("Error while loading library " + fileName + ".");
+        }
+    }
+}

--- a/plugins/rocksdb/src/main/java/greycat/rocksdb/RocksDBStorage.java
+++ b/plugins/rocksdb/src/main/java/greycat/rocksdb/RocksDBStorage.java
@@ -41,6 +41,9 @@ public class RocksDBStorage implements Storage {
     private final String _storagePath;
 
     public RocksDBStorage(String storagePath) {
+        if(System.getProperty("os.arch").equals("arm")) {
+            LibraryLoader.loadArmLibrary("librocksdbjni-linux32");
+        }
         RocksDB.loadLibrary();
         this._storagePath = storagePath;
     }


### PR DESCRIPTION
Add the RocksDB library (.so) compiled on Pi 3 platform (Armv7)

On this platform, the "os.arch" property return is "arm".

About the loading:
`RocksDB.loadLibrary()` is declared in a static body. Thus, the loadLibrary is directly call when we used a function of  `RocksDB`.  This class defined a flag to load only once the library.
As the library is stored in the jar file, it should be extracted, either in the `java.io.tmpdir` folder, or in the folder point by the `ROCKSDB_SHAREDLIB_DIR`  environment variable. 

The simple and only way that I found is to use the mechanism of `System.loadLibrary` of Java that load only once a library, based on the name. As extracting in the `java.io.tmpdir` will create a file with a computed name, the only solution (at least, the only that I found ^^) was to extract the library in `ROCKSDB_SHAREDLIB_DIR`, that keep the name.
To sum-up, on Armv7 platform, the loading procedure is the following:

- extract `arm/librocksdbjni-linux32.so` in `ROCKSDB_SHAREDLIB_DIR`
- load it using `System.loadlibrary`
- RocksDB will extract (and probably overwritte) `librocksdbjni-linux32.so` (the Intel 32 version)
- as it detect that we are on a linux 32-bits, it will try to load it
- `System.loadlibrary` will try to load, and as it already load a library with the same name, it will do nothing
- RocksDB will tag the library has loaded, and used the ARM-32bits version