### PR TITLE
Fixing a null pointer exception in the cloneFor method

### DIFF
--- a/greycat/src/main/java/greycat/internal/heap/HeapDoubleArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapDoubleArray.java
@@ -159,8 +159,9 @@ class HeapDoubleArray implements DoubleArray {
 
     public final HeapDoubleArray cloneFor(HeapContainer target) {
         HeapDoubleArray cloned = new HeapDoubleArray(target);
-        if (_backend != null)
+        if (_backend != null) {
             cloned.initWith(_backend);
+        }
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapDoubleArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapDoubleArray.java
@@ -159,7 +159,8 @@ class HeapDoubleArray implements DoubleArray {
 
     public final HeapDoubleArray cloneFor(HeapContainer target) {
         HeapDoubleArray cloned = new HeapDoubleArray(target);
-        cloned.initWith(_backend);
+        if (_backend != null)
+            cloned.initWith(_backend);
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapIntArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapIntArray.java
@@ -159,8 +159,9 @@ class HeapIntArray implements IntArray {
 
     public final HeapIntArray cloneFor(HeapContainer target) {
         HeapIntArray cloned = new HeapIntArray(target);
-        if (_backend != null)
+        if (_backend != null) {
             cloned.initWith(_backend);
+        }
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapIntArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapIntArray.java
@@ -159,7 +159,8 @@ class HeapIntArray implements IntArray {
 
     public final HeapIntArray cloneFor(HeapContainer target) {
         HeapIntArray cloned = new HeapIntArray(target);
-        cloned.initWith(_backend);
+        if (_backend != null)
+            cloned.initWith(_backend);
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapLongArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapLongArray.java
@@ -103,25 +103,25 @@ class HeapLongArray implements LongArray {
     }
 
     @Override
-    public final synchronized void addElement(long value){
+    public final synchronized void addElement(long value) {
         if (_backend == null) {
             _backend = new long[]{value};
         } else {
-        long[] newBackend = new long[_backend.length + 1];
-        System.arraycopy(_backend, 0, newBackend, 0, _backend.length);
-        newBackend[_backend.length] = value;
-        _backend = newBackend;
+            long[] newBackend = new long[_backend.length + 1];
+            System.arraycopy(_backend, 0, newBackend, 0, _backend.length);
+            newBackend[_backend.length] = value;
+            _backend = newBackend;
         }
         _parent.declareDirty();
     }
 
     @Override
-    public final synchronized void addAll(long[] values){
-        if(_backend == null) initWith(values);
+    public final synchronized void addAll(long[] values) {
+        if (_backend == null) initWith(values);
         long[] newBackend = new long[_backend.length + values.length];
         System.arraycopy(_backend, 0, newBackend, 0, _backend.length);
         System.arraycopy(values, 0, newBackend, _backend.length, values.length);
-        _backend =newBackend;
+        _backend = newBackend;
         _parent.declareDirty();
     }
 
@@ -158,7 +158,8 @@ class HeapLongArray implements LongArray {
 
     public final HeapLongArray cloneFor(HeapContainer target) {
         HeapLongArray cloned = new HeapLongArray(target);
-        cloned.initWith(_backend);
+        if (_backend != null)
+            cloned.initWith(_backend);
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapLongArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapLongArray.java
@@ -158,8 +158,9 @@ class HeapLongArray implements LongArray {
 
     public final HeapLongArray cloneFor(HeapContainer target) {
         HeapLongArray cloned = new HeapLongArray(target);
-        if (_backend != null)
+        if (_backend != null) {
             cloned.initWith(_backend);
+        }
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapStringArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapStringArray.java
@@ -157,7 +157,8 @@ class HeapStringArray implements StringArray {
 
     public final HeapStringArray cloneFor(HeapContainer target) {
         HeapStringArray cloned = new HeapStringArray(target);
-        cloned.initWith(_backend);
+        if (_backend != null)
+            cloned.initWith(_backend);
         return cloned;
     }
 

--- a/greycat/src/main/java/greycat/internal/heap/HeapStringArray.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapStringArray.java
@@ -157,8 +157,9 @@ class HeapStringArray implements StringArray {
 
     public final HeapStringArray cloneFor(HeapContainer target) {
         HeapStringArray cloned = new HeapStringArray(target);
-        if (_backend != null)
+        if (_backend != null) {
             cloned.initWith(_backend);
+        }
         return cloned;
     }
 


### PR DESCRIPTION
The new Array had a problem of null pointer exception in case of clone, the initWith was called without checking the content of the current backend.