### PR TITLE
Long Long Array map behaviour modification

### DIFF
--- a/greycat/src/main/java/greycat/internal/heap/HeapLongLongArrayMap.java
+++ b/greycat/src/main/java/greycat/internal/heap/HeapLongLongArrayMap.java
@@ -288,14 +288,22 @@ class HeapLongLongArrayMap implements LongLongArrayMap {
     }
 
     @Override
-    public final LongLongArrayMap put(final long insertKey, final long insertValue) {
+    public final LongLongArrayMap putWithoutCheck(final long insertKey, final long insertValue) {
         synchronized (parent) {
-            internal_put(insertKey, insertValue, false);
+            internal_put(insertKey, insertValue, false, false);
         }
         return this;
     }
 
-    private void internal_put(final long insertKey, final long insertValue, final boolean initial) {
+    @Override
+    public final LongLongArrayMap put(final long insertKey, final long insertValue) {
+        synchronized (parent) {
+            internal_put(insertKey, insertValue, false, true);
+        }
+        return this;
+    }
+
+    private void internal_put(final long insertKey, final long insertValue, final boolean initial, final boolean check) {
         if (keys == null) {
             reallocate(Constants.MAP_INITIAL_CAPACITY);
             setKey(0, insertKey);
@@ -312,12 +320,14 @@ class HeapLongLongArrayMap implements LongLongArrayMap {
             int currentHash = hash(insertKeyHash);
             int m = currentHash;
             int found = -1;
-            while (m >= 0) {
-                if (insertKey == key(m) && insertValue == value(m)) {
-                    found = m;
-                    break;
+            if (check) {
+                while (m >= 0) {
+                    if (insertKey == key(m) && insertValue == value(m)) {
+                        found = m;
+                        break;
+                    }
+                    m = next(m);
                 }
-                m = next(m);
             }
             if (found == -1) {
                 final int lastIndex = mapSize;
@@ -371,7 +381,7 @@ class HeapLongLongArrayMap implements LongLongArrayMap {
                         waitingVal = true;
                     } else {
                         waitingVal = false;
-                        internal_put(previousKey, Base64.decodeToLongWithBounds(buffer, previous, cursor), true);
+                        internal_put(previousKey, Base64.decodeToLongWithBounds(buffer, previous, cursor), true,false);
                     }
                 }
                 previous = cursor + 1;
@@ -385,7 +395,7 @@ class HeapLongLongArrayMap implements LongLongArrayMap {
             reallocate(Base64.decodeToIntWithBounds(buffer, previous, cursor));
         } else {
             if (waitingVal) {
-                internal_put(previousKey, Base64.decodeToLongWithBounds(buffer, previous, cursor), true);
+                internal_put(previousKey, Base64.decodeToLongWithBounds(buffer, previous, cursor), true,false);
             }
         }
         return cursor;

--- a/greycat/src/main/java/greycat/struct/LongLongArrayMap.java
+++ b/greycat/src/main/java/greycat/struct/LongLongArrayMap.java
@@ -25,6 +25,8 @@ public interface LongLongArrayMap extends Map {
      */
     long[] get(long key);
 
+    LongLongArrayMap putWithoutCheck(long insertKey, long insertValue);
+
     /**
      * Add the tuple key/value to the getOrCreateMap.
      * This getOrCreateMap allows keys conflicts.

--- a/greycat/src/main/java/greycat/struct/proxy/LongLongArrayMapProxy.java
+++ b/greycat/src/main/java/greycat/struct/proxy/LongLongArrayMapProxy.java
@@ -49,6 +49,12 @@ public final class LongLongArrayMapProxy implements LongLongArrayMap {
     }
 
     @Override
+    public LongLongArrayMap putWithoutCheck(long insertKey, long insertValue) {
+        check();
+        return _elem.putWithoutCheck(insertKey,insertValue);
+    }
+
+    @Override
     public final void each(final LongLongArrayMapCallBack callback) {
         _elem.each(callback);
     }


### PR DESCRIPTION
Long Long array map is acting like a long long set map by default, adding a putWithoutCheck method to allow duplicate key,value. 

Remove the check from the loader as the choice has already been made when the map was first filled.